### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ preserved in the final build. For example, if you create a user, upload data,
 or run jobs - all of these will be preserved after the file system build
 process is completed. It it thus a good idea to see what has broken, find a
 permanent fix for it, update the build process and build everything again.
-Unfortunately, this does not apply to tools installed from the Toolshed becasue
+Unfortunately, this does not apply to tools installed from the Toolshed because
 it is likely you will not have control over those tools. Those tools need to be
 repaired manually/via Galaxy.
 


### PR DESCRIPTION
@galaxyproject, I've corrected a typographical error in the documentation of the [galaxy-cloudman-playbook](https://github.com/galaxyproject/galaxy-cloudman-playbook) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.